### PR TITLE
Update s0-dongle.yaml

### DIFF
--- a/s0-dongle.yaml
+++ b/s0-dongle.yaml
@@ -1,12 +1,13 @@
 substitutions:
-  device_name: s0-dongle
+  device_name: s0_dongle_unitname
+  friendly_name: S0 Dongle Unitname
   device_description: "S0 module to read S0 interfaces (pulse counters)"
-  friendly_name: S0-Dongle
-  p_version: "v22.12.1"
+  p_version: "v22.12.1-Nijhuis"
 
 esphome:
   name: ${device_name}
-  comment: "${device_description}" 
+  friendly_name: ${friendly_name}
+  comment: ${device_description} 
   name_add_mac_suffix: false
   project:
     name: smartstuff.s0-dongle
@@ -50,6 +51,8 @@ logger:
   esp8266_store_log_strings_in_flash: False
 
 api:
+#  encryption:
+#    key: 
 #via Home Assistant Ontwikkelhulpmiddelen > services zoeken op esphome.watermeter_set_water_reading en via deze methode de juiste beginstand invoeren
 #   reboot_timeout: 0s
   services:
@@ -78,12 +81,14 @@ globals:
           
 button:  
   - platform: restart
-    name: "_Restart device"
+    id: button_restart_device
+    name: Restart Device
   - platform: factory_reset
-    name: "_Restart with Factory Default Settings"  
+    id: button_factory_reset
+    name: Reset to Factory Defaults
   - platform: template
-    name: "_Reset - Total Energy Counter"
     id: button_reset_total
+    name: Reset Total Energy
     on_press:
       - pulse_meter.set_total_pulses:
           id: pulse
@@ -91,12 +96,13 @@ button:
             
 sensor:
   - platform: pulse_meter
+    id: pulse
+    name: Current Power
     pin: 
       number: 5
       mode:
         input: true
         pullup: true #v3.5 aanzetten
-    id: pulse
     state_class: measurement
     unit_of_measurement: 'W'
     device_class: power
@@ -107,8 +113,8 @@ sensor:
       #- multiply: 0.06 # (60s/1000 pulses per kWh)
       - lambda: return x * ((60.0 / id(pulse_rate)) * 1000.0);
     total:
-      name: "S0 Total Energy"
       id: pulse_tot
+      name: Total Energy
       unit_of_measurement: "kWh"
       icon: mdi:circle-slice-3
       state_class: total_increasing
@@ -116,13 +122,9 @@ sensor:
       accuracy_decimals: 3
       filters:
         - lambda: return x * (1.0 / id(pulse_rate));
-
-  - platform: uptime
-    name: "Uptime"
-
   - platform: total_daily_energy
-    name: 'S0 Daily Energy'
-    id:   
+    id: daily_pulse
+    name: Daily Energy
     power_id: pulse
     unit_of_measurement: 'kWh'
     icon: mdi:circle-slice-3
@@ -132,32 +134,50 @@ sensor:
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001
+  - platform: uptime
+    id: device_uptime
+    name: Device Uptime
 
 # Enable time component to reset energy at midnight
 # https://esphome.io/components/time.html#home-assistant-time-source
 time:
   - platform: homeassistant
     id: homeassistant_time
+    timezone: "Europe/Amsterdam"
 
 text_sensor:
+  - platform: template
+    id: device_time
+    name: Device Time
+    lambda: |-
+      char str[17];
+      time_t currTime = id(homeassistant_time).now().timestamp;
+      strftime(str, sizeof(str), "%Y-%m-%d %H:%M", localtime(&currTime));
+      return  { str };
+    update_interval: 60s
+    
   - platform: wifi_info
     ip_address:
-      name: IP-adres
+      id: ip_address
+      name: IP address
       icon: mdi:ip-network
     ssid:
-      name: Netwerk
+      id: network_name
+      name: Network Name
       icon: mdi:access-point-network
     mac_address:
-      name: Mac-adres
+      id: mac_address
+      name: Mac address
       icon: mdi:folder-key-network-outline
       
   - platform: template
-    name: "Config Version"
+    id: config_version
+    name: Config Version
     icon: "mdi:label-outline"
     update_interval: 6h
     lambda: return {"$p_version"};
       
   - platform: version
-    name: "ESPHome Version"
+    id: esp_home_version
+    name: ESPHome Version
     hide_timestamp: true
-


### PR DESCRIPTION
Couple of changes that are helpfull when using multiple S0 Dongles in your network.

- added a friendly name to the ESP, used by HomeAssistant to create unique sensor-ids
- added id's to sensors and buttons
- changed a few names to be more user friendly
- added sensor 'device time'
- sensor 'current power' available as a sensor in Home Assistant