### PR TITLE
Also export current tariff to HA (p1ep)

### DIFF
--- a/p1ep.yaml
+++ b/p1ep.yaml
@@ -71,6 +71,11 @@ dsmr:
  water_mbus_id: 2
 #  crc_check: false #dsmr2
 
+globals:
+  - id: current_tariff_global
+    type: std::string
+    initial_value: '"unknown"'
+
 button:  
   - platform: restart
     name: "_Restart device"
@@ -230,6 +235,24 @@ text_sensor:
         name: "Gas meter ID"
 #     equipment_id:
 #         name: "Smart meter ID"
+    electricity_tariff:
+      name: "Internal tariff"
+      internal: True
+      on_value:
+        then:
+          - lambda: |-
+              if (x == "0001") {
+                id(current_tariff_global) = "low";
+              } else if (x == "0002") {
+                id(current_tariff_global) = "normal";
+              } else {
+                id(current_tariff_global) = "unknown";
+              }
+  - platform: template
+    name: "Current Tariff"
+    icon: "mdi:transmission-tower"
+    lambda: |-
+      return id(current_tariff_global);
   - platform: version
     name: "_ESPHome Version"
     hide_timestamp: true

--- a/p1ep.yaml
+++ b/p1ep.yaml
@@ -253,6 +253,15 @@ text_sensor:
     icon: "mdi:transmission-tower"
     lambda: |-
       return id(current_tariff_global);
+  - platform: template
+    name: "Current Tariff (parsed)"
+    icon: "mdi:transmission-tower"
+    lambda: |-
+      std::string s = id(current_tariff_global);
+      if (!s.empty()) {
+        s[0] = ::toupper(s[0]);
+      }
+      return s;
   - platform: version
     name: "_ESPHome Version"
     hide_timestamp: true


### PR DESCRIPTION
OBIS: 0-0:96.14.0 specifies in which current tariff we are. This is typically indicated by 0001 (low) or 0002 (normal) tariff. 

This will read and parse this data to provide a drop-in replacement for however sernet actually provides the same piece of information.

It's not the nicest piece of code so it could contain some bugs but it works (after about a minute, no idea why, not an expert on ESPHome).
<img width="919" height="409" alt="Screenshot_2026-06-01_02-33-06" src="https://github.com/user-attachments/assets/21b9a4e0-dd3c-4ce5-985f-8d2e38528467" />
